### PR TITLE
Prefix events URL with events/

### DIFF
--- a/src/Evlog.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Evlog.Web/Extensions/ServiceCollectionExtensions.cs
@@ -42,7 +42,7 @@ namespace Evlog.Web.Extensions
             services.AddRouting(options => options.LowercaseUrls = true)
                     .AddMvc()
                     .AddRazorPagesOptions(options => {
-                        options.Conventions.AddPageRoute("/Events/View", "{slug}");
+                        options.Conventions.AddPageRoute("/Events/View", "events/{slug}");
                     });
         }
 


### PR DESCRIPTION
An example URL to an event would be:
https://localhost/events/example-event-slug

The change is prevent the route from being executed for invalid requests (eg. missing image url).