### PR TITLE
Do not install .NET SDK 2.1.400 on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,8 +10,6 @@ environment:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
 init:
   - git config --global core.autocrlf input
-install:
-  - cmd: choco install dotnetcore-sdk --version 2.1.400
 before_build:
   - cmd: dotnet restore -v q evlog.sln
 build_script:


### PR DESCRIPTION
The updated SDK 2.1.403 is already available on AppVeyor.